### PR TITLE
correct the email address validation regex

### DIFF
--- a/lib/mail/renderers/rfc_2822.ex
+++ b/lib/mail/renderers/rfc_2822.ex
@@ -17,7 +17,9 @@ defmodule Mail.Renderers.RFC2822 do
   @address_types ["From", "To", "Reply-To", "Cc", "Bcc"]
 
   # https://tools.ietf.org/html/rfc2822#section-3.4.1
-  @email_validation_regex ~r/\w+@\w+\.\w+/
+  # https://tools.ietf.org/html/rfc2822#section-3.2.4
+  # anchor the regex to force a full match
+  @email_validation_regex ~r(^[\w!#$%&'*+\-/=?^`{|}~.]+@[\w!#$%&'*+\-/=?^`{|}~.]+\.[\w!#$%&'*+\-/=?^`{|}~]+$)
 
   @doc """
   Renders a message according to the RFC2882 spec


### PR DESCRIPTION
A number of characters (including, particularly "-") are legal in email addresses but not included in the original regex. Also, the regex was not anchored, so in many cases where an email included a character not allowed in the regex, it would still pass as a partial match, thus possibly faking out tests in a confusing way. And of course that would also allow many illegal addresses to pass.